### PR TITLE
feat : 유저페이지 계정 공개 / 비공개에 따른 기능

### DIFF
--- a/src/main/java/com/fluffytime/userpage/controller/UserPageController.java
+++ b/src/main/java/com/fluffytime/userpage/controller/UserPageController.java
@@ -1,5 +1,8 @@
 package com.fluffytime.userpage.controller;
 
+import com.fluffytime.domain.User;
+import com.fluffytime.userpage.service.UserPageService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -11,9 +14,22 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Slf4j
 public class UserPageController {
 
+    private final UserPageService userPageService;
+
     @GetMapping("/userpages/{nickname}")
-    public String userPage(@PathVariable(name = "nickname") String nickname) {
+    public String userPage(@PathVariable(name = "nickname") String nickname,
+        HttpServletRequest httpServletRequest) {
         log.info("유저페이지 접근");
-        return "userpage/userpage";
+        // 로그인한 유저 찾기
+        User user = userPageService.findByAccessToken(httpServletRequest);
+        // 로그인한 유저와 유저 페이지의 유저와 동일인인지 체크
+        Boolean isAuthorized = userPageService.isUserAuthorized(user.getNickname(), nickname);
+        if (isAuthorized) {
+            // 본인 일시 마이페이지로 이동
+            return "redirect:/mypage/mypage";
+        } else {
+            // 유저페이지 이동
+            return "userpage/userpage";
+        }
     }
 }

--- a/src/main/java/com/fluffytime/userpage/response/UserPageInformationDto.java
+++ b/src/main/java/com/fluffytime/userpage/response/UserPageInformationDto.java
@@ -25,11 +25,13 @@ public class UserPageInformationDto {
     private Long petAge;  // 애완동물 나이
     private String intro;    // 소개글
     private String fileUrl; // 프로필 사진 등록 URL
+    private String publicStatus; // 프로필 공개/비공개 여부
 
     @Builder
     public UserPageInformationDto(String nickname,
         List<PostDto> postsList,
-        String petName, String petSex, Long petAge, String intro, String fileUrl) {
+        String petName, String petSex, Long petAge, String intro, String fileUrl,
+        String publicStatus) {
         this.nickname = nickname;
         this.postsList = postsList;
         this.petName = petName;
@@ -37,5 +39,6 @@ public class UserPageInformationDto {
         this.petAge = petAge;
         this.intro = intro;
         this.fileUrl = fileUrl;
+        this.publicStatus = publicStatus;
     }
 }

--- a/src/main/java/com/fluffytime/userpage/service/UserPageService.java
+++ b/src/main/java/com/fluffytime/userpage/service/UserPageService.java
@@ -64,6 +64,11 @@ public class UserPageService {
         return findUserById(userId);
     }
 
+    // 접근한 사용자와 실제 권한을 가진 사용자가 동일한지 판단하는 메서드
+    public boolean isUserAuthorized(String accessNickname, String actuallyNickname) {
+        return accessNickname.equals(actuallyNickname);
+    }
+
 
     // 유저 페이지 정보 불러오기 응답 dto 구성
     @Transactional(readOnly = true)
@@ -100,6 +105,7 @@ public class UserPageService {
                 .petAge(profile.getPetAge()) // 반려동물 나이
                 .intro(profile.getIntro()) // 소개글
                 .fileUrl(myPageService.profileFileUrl(profile.getProfileImages())) // 프로필 파일 경로
+                .publicStatus(profile.getPublicStatus()) // 프로필 공개 여부
                 .build();
 
             return userPageInformationDto;

--- a/src/main/resources/static/css/userpage/userpage.css
+++ b/src/main/resources/static/css/userpage/userpage.css
@@ -196,6 +196,25 @@
   font-size: 40px;
 }
 
+/*비공개 계정 */
+#private_account {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  gap: 1rem;
+}
+
+#lock {
+  font-size: 5rem;
+}
+
+#lock_comment1, #lock_comment1 {
+  font-size: 40px;
+}
 
 /* 게시글 이미지 */
 .posts img {

--- a/src/main/resources/static/js/userpage/userpage.js
+++ b/src/main/resources/static/js/userpage/userpage.js
@@ -65,12 +65,20 @@ function handleUserData(data) {
     img.src = data.fileUrl;
   }
 
-  // 해당 유저의 게시글이 있을시 렌더링 처리
-  if (data.postsList !== null) {
-    renderPosts(data.postsList);
-  } else {
+  console.log("타입 확인 코드 !!!!!!!" + typeof data.publicStatus);
+  // 해당 유저의 계정이 공개 계정일때
+  if (data.publicStatus === "1") {
+    (data.postsList !== null) ? renderPosts(data.postsList) : getElement(
+        'no_post').style.display = 'flex';
+
+  } else { // 해당 유저의 계정이 비공개 계정일때
+    // 추후 팔로우 관계일시에는 게시물이 보이게 변경할 예정
+    // if (data.postsList !== null) {
+    //   renderPosts(data.postsList);
+    // } else {
     // 게시글이 없을시 문구 출력
-    getElement('no_post').style.display = 'flex';
+    getElement('private_account').style.display = 'flex';
+    // }
   }
 }
 

--- a/src/main/resources/templates/userpage/userpage.html
+++ b/src/main/resources/templates/userpage/userpage.html
@@ -84,13 +84,20 @@
       <p id="post_create" class="material-symbols-rounded">no_photography</p>
       <p id="post_comment">게시물 없음</p>
     </div>
+
+    <div id="private_account">
+      <p id="lock" class="material-symbols-rounded">lock_person</p>
+      <p id="lock_comment1">비공개 계정입니다.</p>
+      <p id="lock_comment2">게시물을 보려면 팔로우하세요.</p>
+    </div>
+
   </section>
 </div>
 
 
 <th:block th:replace="~{/common/createModal :: createModal}"></th:block>
 <!-- 임시 저장 모달 -->
-<th:block th:replace="~{common/tempModal :: tempModal}" ></th:block>
+<th:block th:replace="~{common/tempModal :: tempModal}"></th:block>
 
 <script th:src="@{/js/mypage/mypageNav.js}"></script>
 


### PR DESCRIPTION
1. 프로필 비공개 설정 기능 개선
- 유저가 프로필을 비공개로 설정할 경우, 해당 유저의 게시물이 존재하더라도 "비공개 계정입니다"라는 메시지가 표시되도록 구현
- 향후 팔로우 기능이 구현되면, 팔로우한 유저에 한해서만 게시물 목록이 보이도록 수정할 예정
- 비공개 계정 여부는 profile 테이블의 public_status 속성을 참고

< 참고 사항 >
- 게시물과 검색 기능은 비공개 계정과 직접적인 연관은 없으나, 홈과 탐색 화면에서 비공개 계정의 게시글이 표시되지 않도록 해야 합니다 (현재는 임시저장 글 외에 전체 글을 불러오도록 설정되어 있음)
- 단, 홈 화면에서는 팔로우한 계정의 게시물은 정상적으로 보여야 하므로, 이 부분은 추후 수정하는 것이 좋을 듯합니다.

2. 유저 페이지 로직 수정
- 현재 본인 유저 페이지에 들어가도 다른 유저의 페이지처럼 보이는 문제가 있습니다. (당연히 구현을 안했으니까...) -> 본인 유저페이지 들어갈시 마이페이지로 리다이렉트 하도록 설정
- 예시: 사용자가 testuser일 때, http://localhost:8080/userpages/testuser로 접근하면 http://localhost:8080/mypage/testuser로 리다이렉트되도록 수정합니다.