### PR TITLE
✨ Feat: 토큰 인증 실패 재로그인 시 이전 경로로 리디렉션

### DIFF
--- a/src/main/java/com/fluffytime/auth/jwt/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/fluffytime/auth/jwt/exception/CustomAuthenticationEntryPoint.java
@@ -77,7 +77,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
                 JwtResponseProvider.setResponse(response, JwtErrorCode.UNKNOWN_ERROR);
             }
         }
-        response.sendRedirect("/login");
+        String requestURI = request.getRequestURI();
+        log.info("redirect url = {}", request.getRequestURI());
+        response.sendRedirect("/login?redirectURL="+requestURI);
     }
 
     // 사용자 요청이 RESTful라면 이에 대한 처리 구현

--- a/src/main/java/com/fluffytime/user/controller/UserController.java
+++ b/src/main/java/com/fluffytime/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.fluffytime.user.controller;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Slf4j
 @Controller

--- a/src/main/java/com/fluffytime/user/controller/api/UserApiController.java
+++ b/src/main/java/com/fluffytime/user/controller/api/UserApiController.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -59,9 +60,20 @@ public class UserApiController {
 
     // 로그인
     @PostMapping("login")
-    public ResponseEntity<Void> login(@RequestBody @Valid LoginUser loginUser, HttpServletResponse response) {
+    public ResponseEntity<Void> login(
+        @RequestBody @Valid LoginUser loginUser,
+        @RequestParam(defaultValue = "/") String redirectURL,
+        HttpServletResponse response
+    ) {
         loginService.loginProcess(response,loginUser);
-        return ResponseEntity.status(HttpStatus.OK).build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.LOCATION, redirectURL);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .headers(headers)
+            .build();
     }
 
     // 로그아웃

--- a/src/main/resources/static/js/login/login.js
+++ b/src/main/resources/static/js/login/login.js
@@ -44,15 +44,37 @@ async function loginProcess(event) {
     return;
   }
 
+
   // 폼 데이터를 JSON으로 변환
   const jsonData = {
     email: email,
     password: password
   };
 
+  // 현재 화면 URL을 가져옵니다.
+  const currentUrl = window.location.href;
+
+  // URL 객체를 생성합니다.
+  const url = new URL(currentUrl);
+
+  // URLSearchParams 객체를 사용하여 쿼리 파라미터를 추출합니다.
+  const queryParams = new URLSearchParams(url.search);
+
+  // 'redirectURL' 쿼리 파라미터 추출
+  const redirectURL = queryParams.get('redirectURL');
+
+  let loginApiUri;
+
+  // target API URI
+  if (redirectURL) {
+    loginApiUri = `/api/users/login?redirectURL=${redirectURL}`;
+  } else {
+    loginApiUri = '/api/users/login';
+  }
+
   try {
     const response = await fetch(
-        '/api/users/login', {
+        loginApiUri, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json'
@@ -67,7 +89,7 @@ async function loginProcess(event) {
     }
     console.log("로그인 성공")
     localStorage.setItem('lastRefreshTime', new Date().getTime());
-    window.location.href = '/';
+    window.location.href = response.headers.get("Location"); // 원하는 URL로 변경;
 
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
<추가사항>
1. 토큰 인증 실패 로그아웃 시, 이전 화면 리디렉션 기능 구현
- 토큰이 인증 실패하여 로그아웃 되었을때, 재로그인 하면 이전에 있었던 화면으로 돌아갑니다.
- 이전 화면의 URI 경로를 login 경로의 파라미터로 가지고 있다가 해당 파라미터를 이용하여 로그인 시 해당 화면으로 돌아갑니다.
- 단, 로그아웃 버튼 클릭 후 재로그인 시에는 홈 화면으로 시작합니다.