### PR TITLE
✨ Feat: 인증 유저 접근 불가 페이지 설정

### DIFF
--- a/src/main/java/com/fluffytime/config/WebConfig.java
+++ b/src/main/java/com/fluffytime/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.fluffytime.config;
+
+import com.fluffytime.auth.jwt.util.JwtTokenizer;
+import com.fluffytime.user.interceptor.LoginCheckInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtTokenizer jwtTokenizer;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LoginCheckInterceptor(jwtTokenizer))
+            .order(1)
+            .addPathPatterns(
+                "/login",
+                "/join/**"
+            );
+    }
+}

--- a/src/main/java/com/fluffytime/user/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/fluffytime/user/interceptor/LoginCheckInterceptor.java
@@ -1,0 +1,29 @@
+package com.fluffytime.user.interceptor;
+
+import com.fluffytime.auth.jwt.util.JwtTokenizer;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenizer jwtTokenizer;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) throws Exception {
+
+        String accessToken = jwtTokenizer.getTokenFromCookie(request, "accessToken");
+
+        if (accessToken == null) {
+            return true;
+        }
+        log.info("이미 로그인된 사용자입니다. 해당 페이지에 접근할 수 없습니다.");
+        response.sendRedirect("/");
+        return false;
+    }
+}


### PR DESCRIPTION
<추가 기능>
- 인증된 유저가 접근 할 수 없는 페이지 설정. 
   - 인증된 유저는 특정 페이지(login, join) 등에 접근하지 못합니다. 
  - interceptor 사용하여 인증 유저 접근 차단
  - 접근 시 홈 화면으로 리디렉션