### PR TITLE
🚑️ Hotfix : 웹소켓 도메인으로 변경

### DIFF
--- a/src/main/resources/static/js/chat/chat.js
+++ b/src/main/resources/static/js/chat/chat.js
@@ -181,7 +181,8 @@ function setupWebSocket(roomName, recipient, recentChat) {
     ws.close(); // 기존 WebSocket 연결 종료
   }
 
-  ws = new WebSocket(`ws://${window.location.host}/ws?room=${roomName}`);
+  // ws = new WebSocket(`ws://${window.location.hos}/ws?room=${roomName}`);
+  ws = new WebSocket(`ws://fluffytime.kro.kr:8080/ws?room=${roomName}`);
 
   ws.onmessage = function (event) {
     console.log('Message received: ', event.data);


### PR DESCRIPTION
웹소켓 연결될때 기존 로컬 호스트에서 웹소켓 도메인으로 잡도록 변경